### PR TITLE
Feature #w1 회원 정보 수정 기능 구현

### DIFF
--- a/1Week_Mission/src/main/java/com/ll/finalProject/base/HomeController.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/base/HomeController.java
@@ -1,0 +1,12 @@
+package com.ll.finalProject.base;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HomeController {
+    @GetMapping("/")
+    public String main() {
+        return "index";
+    }
+}

--- a/1Week_Mission/src/main/java/com/ll/finalProject/base/TestInitData.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/base/TestInitData.java
@@ -1,0 +1,21 @@
+package com.ll.finalProject.base;
+
+import com.ll.finalProject.member.service.MemberService;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@Profile("test")
+public class TestInitData {
+    @Bean
+    CommandLineRunner init(MemberService memberService, PasswordEncoder passwordEncoder) {
+        return args -> {
+            for (int i = 1; i <= 4; i++) {
+                memberService.register("user" + i, "1234", "user" + i + "@test.com");
+            }
+        };
+    }
+}

--- a/1Week_Mission/src/main/java/com/ll/finalProject/base/exception/EmailDuplicatedException.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/base/exception/EmailDuplicatedException.java
@@ -1,0 +1,5 @@
+package com.ll.finalProject.base.exception;
+
+public class EmailDuplicatedException extends RuntimeException {
+    public EmailDuplicatedException(String message) { super(message);}
+}

--- a/1Week_Mission/src/main/java/com/ll/finalProject/base/exception/NicknameDuplicatedException.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/base/exception/NicknameDuplicatedException.java
@@ -1,0 +1,7 @@
+package com.ll.finalProject.base.exception;
+
+public class NicknameDuplicatedException extends RuntimeException {
+    public NicknameDuplicatedException(String message) {
+        super(message);
+    }
+}

--- a/1Week_Mission/src/main/java/com/ll/finalProject/form/MemberModifyForm.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/form/MemberModifyForm.java
@@ -1,0 +1,21 @@
+package com.ll.finalProject.form;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+
+@Getter
+@Setter
+public class MemberModifyForm {
+    @NotEmpty(message = "이메일을 입력해주세요")
+    @Email(message = "올바른 이메일 형식으로 입력해주세요")
+    private String email;
+
+    @NotEmpty(message = "닉네임을 입력해주세요")
+    private String nickname;
+
+    @NotEmpty(message = "비밀번호를 입력해주세요")
+    private String password;
+}

--- a/1Week_Mission/src/main/java/com/ll/finalProject/form/MemberRegisterForm.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/form/MemberRegisterForm.java
@@ -1,4 +1,4 @@
-package com.ll.finalProject.member;
+package com.ll.finalProject.form;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/1Week_Mission/src/main/java/com/ll/finalProject/member/controller/MemberController.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/member/controller/MemberController.java
@@ -9,6 +9,8 @@ import com.ll.finalProject.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -78,12 +80,15 @@ public class MemberController {
             return "user/my_page_form";
         }
         try {
-            memberService.modify(memberContext.getUsername(), memberModifyForm.getEmail(), memberModifyForm.getNickname());
+            memberService.modify(memberContext.getUsername(), memberModifyForm.getEmail(), memberModifyForm.getNickname(), memberModifyForm.getPassword());
         } catch (EmailDuplicatedException e) {
             bindingResult.reject("EmailDuplicated", e.getMessage());
             return "member/modify_form";
         } catch (NicknameDuplicatedException e) {
             bindingResult.reject("NicknameDuplicated", e.getMessage());
+            return "member/modify_form";
+        } catch (BadCredentialsException e) {
+            bindingResult.reject("PasswordInCorrect", e.getMessage());
             return "member/modify_form";
         }
 

--- a/1Week_Mission/src/main/java/com/ll/finalProject/member/controller/MemberController.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/member/controller/MemberController.java
@@ -1,10 +1,20 @@
 package com.ll.finalProject.member.controller;
 
-import com.ll.finalProject.member.MemberRegisterForm;
+import com.ll.finalProject.base.exception.EmailDuplicatedException;
+import com.ll.finalProject.base.exception.NicknameDuplicatedException;
+import com.ll.finalProject.form.MemberModifyForm;
+import com.ll.finalProject.form.MemberRegisterForm;
+import com.ll.finalProject.member.dto.MemberContext;
 import com.ll.finalProject.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +27,7 @@ import javax.validation.Valid;
 @RequestMapping("/member")
 public class MemberController {
     private final MemberService memberService;
+    private final AuthenticationManager authenticationManager;
 
     @GetMapping("/join")
     public String getMemberRegisterForm(MemberRegisterForm memberRegisterForm) {
@@ -50,7 +61,38 @@ public class MemberController {
     }
 
     @GetMapping("/login")
-    public String login() {
+    public String getLoginForm() {
         return "member/login_form";
+    }
+
+    @GetMapping("/modify")
+    public String getModifyForm(Model model, @AuthenticationPrincipal MemberContext memberContext, MemberModifyForm memberModifyForm) {
+        memberModifyForm.setEmail(memberContext.getEmail());
+        memberModifyForm.setNickname(memberContext.getNickname());
+        return "member/modify_form";
+    }
+
+    @PostMapping("/modify")
+    public String modify(@AuthenticationPrincipal MemberContext memberContext, @Valid MemberModifyForm memberModifyForm, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return "user/my_page_form";
+        }
+        try {
+            memberService.modify(memberContext.getUsername(), memberModifyForm.getEmail(), memberModifyForm.getNickname());
+        } catch (EmailDuplicatedException e) {
+            bindingResult.reject("EmailDuplicated", e.getMessage());
+            return "member/modify_form";
+        } catch (NicknameDuplicatedException e) {
+            bindingResult.reject("NicknameDuplicated", e.getMessage());
+            return "member/modify_form";
+        }
+
+        /* 변경된 세션 등록 */
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(memberContext.getUsername(), memberModifyForm.getPassword()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        return "redirect:/";
     }
 }

--- a/1Week_Mission/src/main/java/com/ll/finalProject/member/dto/MemberContext.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/member/dto/MemberContext.java
@@ -1,0 +1,33 @@
+package com.ll.finalProject.member.dto;
+
+import com.ll.finalProject.member.entity.Member;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+public class MemberContext extends User {
+    private final Long id;
+    private final String nickname;
+    private final String email;
+
+    private Map<String, Object> attributes;
+    private String userNameAttributeName;
+
+    public MemberContext(Member member, List<GrantedAuthority> authorities) {
+        super(member.getUsername(), member.getPassword(), authorities);
+        this.id = member.getId();
+        this.nickname = member.getNickname();
+        this.email = member.getEmail();
+    }
+
+    @Override
+    public Set<GrantedAuthority> getAuthorities() {
+        return super.getAuthorities().stream().collect(Collectors.toSet());
+    }
+}

--- a/1Week_Mission/src/main/java/com/ll/finalProject/member/entity/Member.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/member/entity/Member.java
@@ -24,4 +24,9 @@ public class Member extends BaseEntity {
     private String email;
 
     private int authLevel;
+
+    public void modifyMember(String email, String nickname) {
+        this.email = email;
+        this.nickname = nickname;
+    }
 }

--- a/1Week_Mission/src/main/java/com/ll/finalProject/member/repository/MemberRepository.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/member/repository/MemberRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByusername(String username);
+    Optional<Member> findByNickname(String nickname);
 }

--- a/1Week_Mission/src/main/java/com/ll/finalProject/member/service/MemberSecurityService.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/member/service/MemberSecurityService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.ll.finalProject.member.MemberRole;
+import com.ll.finalProject.member.dto.MemberContext;
 import com.ll.finalProject.member.entity.Member;
 import com.ll.finalProject.member.repository.MemberRepository;
 import org.springframework.security.core.GrantedAuthority;
@@ -36,6 +37,6 @@ public class MemberSecurityService implements UserDetailsService {
         } else {
             authorities.add(new SimpleGrantedAuthority(MemberRole.USER.getValue()));
         }
-        return new User(member.getUsername(), member.getPassword(), authorities);
+        return new MemberContext(member, authorities);
     }
 }

--- a/1Week_Mission/src/main/java/com/ll/finalProject/member/service/MemberService.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/member/service/MemberService.java
@@ -26,7 +26,7 @@ public class MemberService {
     private final MailService mailService;
 
     public MemberDto register(String username, String password, String email) {
-        return this.register(username, password, email, "none");
+        return this.register(username, password, email, null);
     }
 
     public MemberDto register(String userName, String password, String email, String nickname) {

--- a/1Week_Mission/src/main/java/com/ll/finalProject/member/service/MemberService.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/member/service/MemberService.java
@@ -10,6 +10,7 @@ import com.ll.finalProject.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -44,19 +45,24 @@ public class MemberService {
         return this.modelMapper.map(member, MemberDto.class);
     }
 
-    public MemberDto modify(String username, String email, String nickname) {
+    public MemberDto modify(String username, String email, String nickname, String password) {
         Optional<Member> _member = memberRepository.findByusername(username);
         Member member = _member.get();
-        member.modifyMember(email, nickname);
-        try {
-            memberRepository.save(member);
-        } catch (DataIntegrityViolationException e) {
-            if (memberRepository.findByNickname(nickname).isPresent()) {
-                throw new NicknameDuplicatedException("이미 사용중인 닉네임 입니다.");
-            } else {
-                throw new EmailDuplicatedException("이미 사용중인 email 입니다.");
+        if (passwordEncoder.matches(password, member.getPassword())) {
+            member.modifyMember(email, nickname);
+            try {
+                memberRepository.save(member);
+            } catch (DataIntegrityViolationException e) {
+                if (memberRepository.findByNickname(nickname).isPresent()) {
+                    throw new NicknameDuplicatedException("이미 사용중인 닉네임 입니다.");
+                } else {
+                    throw new EmailDuplicatedException("이미 사용중인 email 입니다.");
+                }
             }
+        } else {
+            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
         }
+
         return modelMapper.map(member, MemberDto.class);
     }
 }

--- a/1Week_Mission/src/main/resources/templates/layout/navbar.html
+++ b/1Week_Mission/src/main/resources/templates/layout/navbar.html
@@ -12,7 +12,10 @@
                     <a class="nav-link" sec:authorize="isAuthenticated()" th:href="@{/member/logout}">로그아웃</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" th:href="@{/member/join}">회원가입</a>
+                    <a class="nav-link" sec:authorize="isAnonymous()" th:href="@{/member/join}">회원가입</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" sec:authorize="isAuthenticated()" th:href="@{/member/modify}">회원정보수정</a>
                 </li>
             </ul>
         </div>

--- a/1Week_Mission/src/main/resources/templates/member/modify_form.html
+++ b/1Week_Mission/src/main/resources/templates/member/modify_form.html
@@ -1,0 +1,20 @@
+<html layout:decorate="~{layout/layout}">
+<div layout:fragment="content" class="container my-3">
+    <form th:action="@{/member/modify}" method="post" th:object="${memberModifyForm}">
+        <div th:replace="form_errors :: formErrorsFragment"></div>
+        <div class="mb-3">
+            <label for="email" class="form-label">email</label>
+            <input type="text" name="email" id="email" class="form-control" th:field="*{email}">
+        </div>
+        <div class="mb-3">
+            <label for="nickname" class="form-label">닉네임</label>
+            <input type="text" name="nickname" id="nickname" class="form-control" th:field="*{nickname}">
+        </div>
+        <div class="mb-3">
+            <label for="password" class="form-label">비밀번호</label>
+            <input type="password" name="password" id="password" class="form-control">
+        </div>
+        <button type="submit" class="btn btn-primary">수정</button>
+    </form>
+</div>
+</html>

--- a/1Week_Mission/src/test/java/com/ll/finalProject/MemberServiceTests.java
+++ b/1Week_Mission/src/test/java/com/ll/finalProject/MemberServiceTests.java
@@ -90,19 +90,40 @@ public class MemberServiceTests {
     @Test
     @DisplayName("회원가입 후 로그인 테스트")
     public void t3() throws Exception {
-        //회원가입
+        //given
         String username = "user1";
         String password = "1234";
         String email = "user1@test.com";
         memberService.register(username, password, email);
 
-        // when
+        //when
         mvc.perform(post("/member/login")
                         .param("username", "user1")
                         .param("password", "1234")
                         .with(csrf()))
-        // then
+        //then
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/"));
+    }
+
+    @Test
+    @DisplayName("회원 정보 수정 테스트")
+    public void t4() throws Exception {
+        //given
+        String username = "user1";
+        String password = "1234";
+        String email = "user1@test.com";
+        MemberDto memberDto = memberService.register(username, password, email);
+
+        //when
+        String newEmail = "newUser1@test.com";
+        String newNickname = "aaa";
+        MemberDto newMemberDto = memberService.modify(username, newEmail, newNickname);
+
+        //then
+        assertThat(memberDto.getEmail()).isNotEqualTo(newMemberDto.getEmail());
+        assertThat(memberDto.getNickName()).isNotEqualTo(newMemberDto.getNickName());
+        assertThat(newMemberDto.getEmail()).isEqualTo(newEmail);
+        assertThat(newMemberDto.getNickName()).isEqualTo(newNickname);
     }
 }


### PR DESCRIPTION
### 작업 개요
회원 정보 수정 기능을 구현했습니다.

### 작업 분류
- [x] 버그 수정
- [x] 신규 기능

### 작업 상세 내용

### feat : 회원 정보 수정 구현 : bdb384cbd1b0a69e8ed2b7971483125a7cb722b9

**1. MemberModifyForm 사용**
수정 가능한 정보인 email / nickname 을 입력받습니다. 추가로 비밀번호를 입력받습니다. 
여기서 비밀번호는 2차 인증의 개념으로 다시 한번 사용자가 맞는지 확인하는 절차입니다. 
(비밀번호는 이곳에서 수정되지 않습니다)

**2. 중복 닉네임, 이메일 확인**
수정된 Member Entity를 DB에 저장할 때 예외가 발생하면 닉네임 중복을 확인합니다.
중복된 닉네임이 존재한다면 `NicknameDuplicatedException`을 발생시킵니다.
이외 예외라면 `EmailDuplicatedException`을 발생시킵니다.

**3. 세션 교체** 
세션에는 여전히 수정 이전 데이터가 남아 있습니다. 따라서 세션 또한 변경해야 합니다.
MemberController -> modify 에서 세션 교체를 구현했습니다.

### fix : 회원 정보 수정 시 비밀번호 인증 로직 구현 : b14f7522658a9b50342bcac8308544c6afb1edfd

**1. 비밀번호 인증 로직 구현**
위에서 언급한 2차 인증의 개념으로 비밀번호를 입력받았으나 실제 인증 로직을 구현하지 않았었습니다.
따라서 입력 받은 비밀번호와 DB의 비밀번호가 일치하는지 확인하는 로직을 구현했습니다.
일치하지 않을 시 DB 정보는 수정되지 않습니다. 또한 `BadCredentialsException`을 발생시킵니다.

### test : 회원 정보 수정 테스트 수정 : 48cf9d061f393c2d739897ea9a6b90edf0cc5a57

**1. 테스트 데이터 추가**
원활한 테스트 코드 작성을 위해서 테스트 데이터를 추가했습니다. (user1 ~ user4)

### 생각해볼 문제
1. 비밀번호 인증 로직을 단순하게 구현했는데 더 좋은 방법이 있을 것 같은 느낌...
2. 개발 속도가 늦어서 테스트 케이스 작성이 부실한 점...