### PR TITLE
Feature #w1 비밀번호 변경 기능 구현

### DIFF
--- a/1Week_Mission/src/main/java/com/ll/finalProject/form/MemberModifyPasswordForm.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/form/MemberModifyPasswordForm.java
@@ -1,0 +1,19 @@
+package com.ll.finalProject.form;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotEmpty;
+
+@Getter
+@Setter
+public class MemberModifyPasswordForm {
+    @NotEmpty(message = "이전 비밀번호를 입력해주세요")
+    private String oldPassword;
+
+    @NotEmpty(message = "새 비밀번호를 입력해주세요")
+    private String password;
+
+    @NotEmpty(message = "새 비밀번호 확인을 입력해주세요")
+    private String passwordConfirm;
+}

--- a/1Week_Mission/src/main/java/com/ll/finalProject/member/controller/MemberController.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.ll.finalProject.member.controller;
 import com.ll.finalProject.base.exception.EmailDuplicatedException;
 import com.ll.finalProject.base.exception.NicknameDuplicatedException;
 import com.ll.finalProject.form.MemberModifyForm;
+import com.ll.finalProject.form.MemberModifyPasswordForm;
 import com.ll.finalProject.form.MemberRegisterForm;
 import com.ll.finalProject.member.dto.MemberContext;
 import com.ll.finalProject.member.service.MemberService;
@@ -77,7 +78,7 @@ public class MemberController {
     @PostMapping("/modify")
     public String modify(@AuthenticationPrincipal MemberContext memberContext, @Valid MemberModifyForm memberModifyForm, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
-            return "user/my_page_form";
+            return "member/modify_form";
         }
         try {
             memberService.modify(memberContext.getUsername(), memberModifyForm.getEmail(), memberModifyForm.getNickname(), memberModifyForm.getPassword());
@@ -95,6 +96,32 @@ public class MemberController {
         /* 변경된 세션 등록 */
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(memberContext.getUsername(), memberModifyForm.getPassword()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        return "redirect:/";
+    }
+
+    @GetMapping("/modifyPassword")
+    public String getModifyPasswordForm(Model model, MemberModifyPasswordForm memberModifyPasswordForm) {
+        return "member/modifyPassword_form";
+    }
+
+    @PostMapping("/modifyPassword")
+    public String modifyPassword(@AuthenticationPrincipal MemberContext memberContext, @Valid MemberModifyPasswordForm memberModifyPasswordForm, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return "member/modifyPassword_form";
+        }
+        try {
+            memberService.modifyPassword(memberContext.getUsername(), memberModifyPasswordForm.getOldPassword(), memberModifyPasswordForm.getPassword());
+        } catch (BadCredentialsException e) {
+            bindingResult.reject("PasswordInCorrect", e.getMessage());
+            return "member/modifyPassword_form";
+        }
+
+        /* 변경된 세션 등록 */
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(memberContext.getUsername(), memberModifyPasswordForm.getPassword()));
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
 

--- a/1Week_Mission/src/main/java/com/ll/finalProject/member/entity/Member.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/member/entity/Member.java
@@ -29,4 +29,8 @@ public class Member extends BaseEntity {
         this.email = email;
         this.nickname = nickname;
     }
+
+    public void modifyMemberPassword(String password) {
+        this.password = password;
+    }
 }

--- a/1Week_Mission/src/main/java/com/ll/finalProject/member/service/MemberService.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/member/service/MemberService.java
@@ -65,4 +65,17 @@ public class MemberService {
 
         return modelMapper.map(member, MemberDto.class);
     }
+
+    public MemberDto modifyPassword(String username, String oldPassword, String newPassword) {
+        Optional<Member> _member = memberRepository.findByusername(username);
+        Member member = _member.get();
+        if (passwordEncoder.matches(oldPassword, member.getPassword())) {
+            member.modifyMemberPassword(passwordEncoder.encode(newPassword));
+            memberRepository.save(member);
+        } else {
+            throw new BadCredentialsException("기존 비밀번호가 일치하지 않습니다.");
+        }
+
+        return modelMapper.map(member, MemberDto.class);
+    }
 }

--- a/1Week_Mission/src/main/resources/templates/layout/navbar.html
+++ b/1Week_Mission/src/main/resources/templates/layout/navbar.html
@@ -17,6 +17,9 @@
                 <li class="nav-item">
                     <a class="nav-link" sec:authorize="isAuthenticated()" th:href="@{/member/modify}">회원정보수정</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link" sec:authorize="isAuthenticated()" th:href="@{/member/modifyPassword}">비밀번호수정</a>
+                </li>
             </ul>
         </div>
     </div>

--- a/1Week_Mission/src/main/resources/templates/member/modifyPassword_form.html
+++ b/1Week_Mission/src/main/resources/templates/member/modifyPassword_form.html
@@ -1,0 +1,33 @@
+<html layout:decorate="~{layout/layout}">
+<div layout:fragment="content" class="container my-3">
+    <form th:action="@{/member/modifyPassword}" method="post" th:object="${memberModifyPasswordForm}">
+        <div th:replace="form_errors :: formErrorsFragment"></div>
+        <div class="mb-3">
+            <label for="oldPassword" class="form-label">이전 비밀번호</label>
+            <input type="password" name="oldPassword" id="oldPassword" class="form-control" th:field="*{oldPassword}">
+        </div>
+        <div class="mb-3">
+            <label for="password" class="form-label">새 비밀번호</label>
+            <input type="password" name="password" id="password" class="form-control" th:field="*{password}">
+        </div>
+        <div class="mb-3">
+            <label for="passwordConfirm" class="form-label">새 비밀번호 확인</label>
+            <input type="password" name="passwordConfirm" id="passwordConfirm" class="form-control" th:field="*{passwordConfirm}">
+        </div>
+        <button type="submit" class="btn btn-primary" id="modifyButton">수정</button>
+    </form>
+    <script>
+        window.onload = () => {
+            document.getElementById('modifyButton').addEventListener('click', (e) => {
+                const pwd = document.getElementById("password");
+                const pwdConfirm = document.getElementById("passwordConfirm");
+                if(pwd.value.trim() != pwdConfirm.value.trim()) {
+                    alert("새 비밀번호가 일치하는지 확인해주세요.");
+                    pwdConfirm.select();
+                    e.preventDefault();
+                }
+            });
+        }
+    </script>
+</div>
+</html>


### PR DESCRIPTION
### 작업 개요
비밀번호 변경 기능을 구현했습니다.

### 작업 분류
- [x] 신규 기능

### 작업 상세 내용
1. 이전의 개인정보 변경 기능과 유사하게 구현했습니다. 이전 비밀번호의 경우 DB데이터와 비교가 필요하기 때문에 서비스 계층에서 검증합니다. 불일치시 `BadCredentialsException` 발생합니다.
새비밀번호와 새비밀번호 확인이 다를 경우는 프론트(JS)에서 검증합니다.