### PR TITLE
Feature #w1 아이디, 비밀번호 찾기 기능 구현

### DIFF
--- a/1Week_Mission/build.gradle
+++ b/1Week_Mission/build.gradle
@@ -44,6 +44,10 @@ dependencies {
 
 	/* Convert data type dependency */
 	implementation group: 'org.modelmapper', name: 'modelmapper', version: '3.1.0'
+
+	/* Random String dependency */
+	implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
+
 }
 
 tasks.named('test') {

--- a/1Week_Mission/src/main/java/com/ll/finalProject/base/Util.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/base/Util.java
@@ -2,15 +2,4 @@ package com.ll.finalProject.base;
 
 import com.ll.finalProject.member.dto.MailDto;
 
-public class Util {
-    public static class Mail {
-        public static MailDto getWelcomeMailDto(String email) {
-            MailDto mailDto = new MailDto();
-            mailDto.setAddress(email);
-            mailDto.setTitle("회원가입을 환영합니다!");
-            mailDto.setMessage("마켓앱을 통해 멋진 글을 작성해보세요!");
-
-            return mailDto;
-        }
-    }
-}
+public class Util { }

--- a/1Week_Mission/src/main/java/com/ll/finalProject/base/exception/DataNotFoundException.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/base/exception/DataNotFoundException.java
@@ -1,0 +1,10 @@
+package com.ll.finalProject.base.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "데이터가 존재하지 않습니다.")
+public class DataNotFoundException extends RuntimeException {
+    public DataNotFoundException(String question_not_found) {
+    }
+}

--- a/1Week_Mission/src/main/java/com/ll/finalProject/form/FindPasswordForm.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/form/FindPasswordForm.java
@@ -8,8 +8,11 @@ import javax.validation.constraints.NotEmpty;
 
 @Getter
 @Setter
-public class MemberFindUsernameForm {
+public class FindPasswordForm {
+    @NotEmpty(message = "아이디를 입력해주세요")
+    private String username;
+
     @NotEmpty(message = "이메일은 필수항목입니다.")
-    @Email
+    @Email(message = "올바른 이메일 형식으로 입력해주세요")
     private String email;
 }

--- a/1Week_Mission/src/main/java/com/ll/finalProject/form/FindUsernameForm.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/form/FindUsernameForm.java
@@ -1,0 +1,15 @@
+package com.ll.finalProject.form;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+
+@Getter
+@Setter
+public class FindUsernameForm {
+    @NotEmpty(message = "이메일은 필수항목입니다.")
+    @Email
+    private String email;
+}

--- a/1Week_Mission/src/main/java/com/ll/finalProject/form/MemberFindUsernameForm.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/form/MemberFindUsernameForm.java
@@ -1,0 +1,15 @@
+package com.ll.finalProject.form;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+
+@Getter
+@Setter
+public class MemberFindUsernameForm {
+    @NotEmpty(message = "이메일은 필수항목입니다.")
+    @Email
+    private String email;
+}

--- a/1Week_Mission/src/main/java/com/ll/finalProject/form/ModifyPasswordForm.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/form/ModifyPasswordForm.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.NotEmpty;
 
 @Getter
 @Setter
-public class MemberModifyPasswordForm {
+public class ModifyPasswordForm {
     @NotEmpty(message = "이전 비밀번호를 입력해주세요")
     private String oldPassword;
 

--- a/1Week_Mission/src/main/java/com/ll/finalProject/member/controller/MemberController.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/member/controller/MemberController.java
@@ -3,10 +3,7 @@ package com.ll.finalProject.member.controller;
 import com.ll.finalProject.base.exception.DataNotFoundException;
 import com.ll.finalProject.base.exception.EmailDuplicatedException;
 import com.ll.finalProject.base.exception.NicknameDuplicatedException;
-import com.ll.finalProject.form.MemberFindUsernameForm;
-import com.ll.finalProject.form.MemberModifyForm;
-import com.ll.finalProject.form.MemberModifyPasswordForm;
-import com.ll.finalProject.form.MemberRegisterForm;
+import com.ll.finalProject.form.*;
 import com.ll.finalProject.member.dto.MemberContext;
 import com.ll.finalProject.member.dto.MemberDto;
 import com.ll.finalProject.member.service.MemberService;
@@ -105,18 +102,18 @@ public class MemberController {
     }
 
     @GetMapping("/modifyPassword")
-    public String getModifyPasswordForm(MemberModifyPasswordForm memberModifyPasswordForm) {
+    public String getModifyPasswordForm(ModifyPasswordForm modifyPasswordForm) {
         return "member/modifyPassword_form";
     }
 
     @PostMapping("/modifyPassword")
-    public String modifyPassword(@AuthenticationPrincipal MemberContext memberContext, @Valid MemberModifyPasswordForm memberModifyPasswordForm, BindingResult bindingResult) {
+    public String modifyPassword(@AuthenticationPrincipal MemberContext memberContext, @Valid ModifyPasswordForm modifyPasswordForm, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             return "member/modifyPassword_form";
         }
 
         try {
-            memberService.modifyPassword(memberContext.getUsername(), memberModifyPasswordForm.getOldPassword(), memberModifyPasswordForm.getPassword());
+            memberService.modifyPassword(memberContext.getUsername(), modifyPasswordForm.getOldPassword(), modifyPasswordForm.getPassword());
         } catch (BadCredentialsException e) {
             bindingResult.reject("PasswordInCorrect", e.getMessage());
             return "member/modifyPassword_form";
@@ -124,7 +121,7 @@ public class MemberController {
 
         /* 변경된 세션 등록 */
         Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(memberContext.getUsername(), memberModifyPasswordForm.getPassword()));
+                new UsernamePasswordAuthenticationToken(memberContext.getUsername(), modifyPasswordForm.getPassword()));
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
@@ -132,18 +129,18 @@ public class MemberController {
     }
 
     @GetMapping("/findUsername")
-    public String getFindUsernameForm(MemberFindUsernameForm memberFindUsernameForm) {
+    public String getFindUsernameForm(FindUsernameForm findUsernameForm) {
         return "member/findUsername_form";
     }
 
     @PostMapping("/findUsername")
-    public String findUsername(Model model, @Valid MemberFindUsernameForm memberFindUsernameForm, BindingResult bindingResult) {
+    public String findUsername(Model model, @Valid FindUsernameForm findUsernameForm, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
             return "member/findUsername_form";
         }
 
         try {
-            MemberDto memberDto = memberService.findUsernameByEmail(memberFindUsernameForm.getEmail());
+            MemberDto memberDto = memberService.findUsername(findUsernameForm.getEmail());
             model.addAttribute("memberDto", memberDto);
         } catch (DataNotFoundException e) {
             bindingResult.reject("MemberNotFound", e.getMessage());
@@ -151,5 +148,31 @@ public class MemberController {
         }
 
         return "member/showUsername";
+    }
+
+    @GetMapping("/findPassword")
+    public String getFindPasswordForm(FindPasswordForm findPasswordForm) {
+        return "member/findPassword_form";
+    }
+
+    @PostMapping("/findPassword")
+    public String findPassword(@Valid FindPasswordForm findPasswordForm, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return "member/findPassword_form";
+        }
+
+        try {
+            memberService.findPassword(findPasswordForm.getUsername(), findPasswordForm.getEmail());
+        } catch (DataNotFoundException e) {
+            e.printStackTrace();
+            bindingResult.reject("MemberNotFound", e.getMessage());
+            return "member/findPassword_form";
+        } catch(Exception e) {
+            e.printStackTrace();
+            bindingResult.reject("findPasswordFailed", e.getMessage());
+            return "member/findPassword_form";
+        }
+
+        return "redirect:/";
     }
 }

--- a/1Week_Mission/src/main/java/com/ll/finalProject/member/repository/MemberRepository.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/member/repository/MemberRepository.java
@@ -8,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByusername(String username);
     Optional<Member> findByNickname(String nickname);
+    Optional<Member> findByEmail(String email);
 }

--- a/1Week_Mission/src/main/java/com/ll/finalProject/member/service/MailService.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/member/service/MailService.java
@@ -15,12 +15,23 @@ public class MailService {
     private static final String FROM_ADDRESS = "mailbot883@gmail.com";
 
     @Async("mailExecutor")
-    public void mailSend(MailDto mailDto) {
+    public void welcomeMailSend(String to) {
         SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(mailDto.getAddress());
+        message.setTo(to);
         message.setFrom(MailService.FROM_ADDRESS);
-        message.setSubject(mailDto.getTitle());
-        message.setText(mailDto.getMessage());
+        message.setSubject("회원가입을 축하합니다!");
+        message.setText("원하는 글을 작성하세요!");
+
+        mailSender.send(message);
+    }
+
+    @Async("mailExecutor")
+    public void tempPasswordMailSend(String to, String tempPassword) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setFrom(MailService.FROM_ADDRESS);
+        message.setSubject("임시 비밀번호 발급");
+        message.setText(tempPassword);
 
         mailSender.send(message);
     }

--- a/1Week_Mission/src/main/java/com/ll/finalProject/member/service/MemberService.java
+++ b/1Week_Mission/src/main/java/com/ll/finalProject/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.ll.finalProject.member.service;
 
 import com.ll.finalProject.base.Util;
+import com.ll.finalProject.base.exception.DataNotFoundException;
 import com.ll.finalProject.base.exception.EmailDuplicatedException;
 import com.ll.finalProject.base.exception.NicknameDuplicatedException;
 import com.ll.finalProject.member.dto.MailDto;
@@ -47,6 +48,11 @@ public class MemberService {
 
     public MemberDto modify(String username, String email, String nickname, String password) {
         Optional<Member> _member = memberRepository.findByusername(username);
+
+        if (_member.isEmpty()) {
+            throw new DataNotFoundException("회원이 존재하지 않습니다.");
+        }
+
         Member member = _member.get();
         if (passwordEncoder.matches(password, member.getPassword())) {
             member.modifyMember(email, nickname);
@@ -68,6 +74,11 @@ public class MemberService {
 
     public MemberDto modifyPassword(String username, String oldPassword, String newPassword) {
         Optional<Member> _member = memberRepository.findByusername(username);
+
+        if (_member.isEmpty()) {
+            throw new DataNotFoundException("회원이 존재하지 않습니다.");
+        }
+
         Member member = _member.get();
         if (passwordEncoder.matches(oldPassword, member.getPassword())) {
             member.modifyMemberPassword(passwordEncoder.encode(newPassword));
@@ -77,5 +88,15 @@ public class MemberService {
         }
 
         return modelMapper.map(member, MemberDto.class);
+    }
+
+    public MemberDto findUsernameByEmail(String email) {
+        Optional<Member> _member = memberRepository.findByEmail(email);
+        if (_member.isPresent()) {
+            Member member = _member.get();
+            return modelMapper.map(member, MemberDto.class);
+        } else {
+            throw new DataNotFoundException("해당하는 이메일의 회원이 없습니다.");
+        }
     }
 }

--- a/1Week_Mission/src/main/resources/templates/layout/navbar.html
+++ b/1Week_Mission/src/main/resources/templates/layout/navbar.html
@@ -23,6 +23,9 @@
                 <li class="nav-item">
                     <a class="nav-link" sec:authorize="isAnonymous()" th:href="@{/member/findUsername}">아이디찾기</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link" sec:authorize="isAnonymous()" th:href="@{/member/findPassword}">비밀번호찾기</a>
+                </li>
             </ul>
         </div>
     </div>

--- a/1Week_Mission/src/main/resources/templates/layout/navbar.html
+++ b/1Week_Mission/src/main/resources/templates/layout/navbar.html
@@ -20,6 +20,9 @@
                 <li class="nav-item">
                     <a class="nav-link" sec:authorize="isAuthenticated()" th:href="@{/member/modifyPassword}">비밀번호수정</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link" sec:authorize="isAnonymous()" th:href="@{/member/findUsername}">아이디찾기</a>
+                </li>
             </ul>
         </div>
     </div>

--- a/1Week_Mission/src/main/resources/templates/member/findPassword_form.html
+++ b/1Week_Mission/src/main/resources/templates/member/findPassword_form.html
@@ -1,0 +1,16 @@
+<html layout:decorate="~{layout/layout}">
+<div layout:fragment="content" class="container my-3">
+    <form th:action="@{/member/findPassword}" method="post" th:object="${findPasswordForm}">
+        <div th:replace="form_errors :: formErrorsFragment"></div>
+        <div class="mb-3">
+            <label for="username" class="form-label">아이디</label>
+            <input type="text" name="username" id="username" class="form-control" th:field="*{username}">
+        </div>
+        <div class="mb-3">
+            <label for="email" class="form-label">이메일</label>
+            <input type="text" name="email" id="email" class="form-control" th:field="*{email}">
+        </div>
+        <button type="submit" class="btn btn-primary">찾기(임시 비밀번호 이메일 발송)</button>
+    </form>
+</div>
+</html>

--- a/1Week_Mission/src/main/resources/templates/member/findUsername_form.html
+++ b/1Week_Mission/src/main/resources/templates/member/findUsername_form.html
@@ -1,6 +1,6 @@
 <html layout:decorate="~{layout/layout}">
 <div layout:fragment="content" class="container my-3">
-    <form th:action="@{/member/findUsername}" method="post" th:object="${memberFindUsernameForm}">
+    <form th:action="@{/member/findUsername}" method="post" th:object="${FindUsernameForm}">
         <div th:replace="form_errors :: formErrorsFragment"></div>
         <div class="mb-3">
             <label for="email" class="form-label">이메일</label>

--- a/1Week_Mission/src/main/resources/templates/member/findUsername_form.html
+++ b/1Week_Mission/src/main/resources/templates/member/findUsername_form.html
@@ -1,0 +1,12 @@
+<html layout:decorate="~{layout/layout}">
+<div layout:fragment="content" class="container my-3">
+    <form th:action="@{/member/findUsername}" method="post" th:object="${memberFindUsernameForm}">
+        <div th:replace="form_errors :: formErrorsFragment"></div>
+        <div class="mb-3">
+            <label for="email" class="form-label">이메일</label>
+            <input type="text" name="email" id="email" class="form-control" th:field="*{email}">
+        </div>
+        <button type="submit" class="btn btn-primary">찾기</button>
+    </form>
+</div>
+</html>

--- a/1Week_Mission/src/main/resources/templates/member/modifyPassword_form.html
+++ b/1Week_Mission/src/main/resources/templates/member/modifyPassword_form.html
@@ -1,6 +1,6 @@
 <html layout:decorate="~{layout/layout}">
 <div layout:fragment="content" class="container my-3">
-    <form th:action="@{/member/modifyPassword}" method="post" th:object="${memberModifyPasswordForm}">
+    <form th:action="@{/member/modifyPassword}" method="post" th:object="${modifyPasswordForm}">
         <div th:replace="form_errors :: formErrorsFragment"></div>
         <div class="mb-3">
             <label for="oldPassword" class="form-label">이전 비밀번호</label>

--- a/1Week_Mission/src/main/resources/templates/member/showUsername.html
+++ b/1Week_Mission/src/main/resources/templates/member/showUsername.html
@@ -1,0 +1,7 @@
+<html layout:decorate="~{layout/layout}">
+<div layout:fragment="content" class="container my-3">
+    <div class="text-center">
+        <span th:text="${memberDto.userName}"></span>
+    </div>
+</div>
+</html>


### PR DESCRIPTION
### 작업 개요
이메일로 아이디 찾기 기능을 구현했습니다. 
아이디, 이메일로 임시 비밀번호를 발급받는 기능을 구현했습니다.

### 작업 분류
- [x] 신규 기능

### 작업 상세 내용
### feat : 아이디 찾기 기능 구현 : d14c90eb9b72105cfd83f46ce945f8e99a29d165
Form에서 이메일을 입력받고 해당 이메일과 매칭되는 회원이 존재하는지 찾습니다.
매칭되는 회원이 존재한다면 해당 회원의 username을 리턴합니다.

### feat : 비밀번호 찾기 기능 구현 : 643f89846db9ca20271ce172e4bdb620fc7eac72
마찬가지로 Form에서 아이디와 이메일을 전달받습니다. 회원이 존재하지 않을 경우, 회원은 존재하나 입력한 이메일과 일치하지 않는 경우 예외를 발생시킵니다.
모든 정보가 일치 할 경우 임시 비밀번호를 만듭니다. 여기서는 아래 의존성을 추가해서 랜덤 String 을 만드는 메서드를 사용했습니다.
 ```
/* Random String dependency */
implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
```
`randomAlphanumeric(int count)` : 대소문자, 숫자를 count만큼 랜덤으로 생성
이후 변경된 비밀번호를 `Member`에 적용하고 임시 비밀번호를 메일로 보냅니다.